### PR TITLE
Publish C# CodeUChain v1.0.0 to NuGet

### DIFF
--- a/packages/csharp/CodeUChain.csproj
+++ b/packages/csharp/CodeUChain.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <Compile Remove="tests/**" />
     <Compile Remove="examples/**" />
+    <Compile Remove="test-runner/**" />
   </ItemGroup>
 
 </Project>

--- a/packages/csharp/readme.md
+++ b/packages/csharp/readme.md
@@ -17,6 +17,12 @@ CodeUChain C# provides a clean, async-first architecture for building processing
 
 ## Installation
 
+### NuGet Package
+```bash
+dotnet add package CodeUChain --version 1.0.0
+```
+
+### From Source
 ```bash
 # Clone the repository
 git clone https://github.com/codeuchain/codeuchain.git


### PR DESCRIPTION
This PR publishes the C# CodeUChain package v1.0.0 to NuGet and updates documentation.

## Changes Made:
- Fixed build configuration by excluding test-runner directory from compilation
- Added NuGet installation instructions to C# README
- Package successfully published to NuGet as CodeUChain v1.0.0
- Git tag csharp/v1.0.0 created and pushed

## Package Details:
- **Package Name**: CodeUChain
- **Version**: 1.0.0
- **Registry**: NuGet
- **Installation**: `dotnet add package CodeUChain --version 1.0.0`

This completes the v1.0.0 release across all supported languages (JavaScript, Python, Go, C#).